### PR TITLE
Shared hooks and architecture docs from admin guild

### DIFF
--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -1,0 +1,438 @@
+# Code for Connection: System Architecture
+
+## What This System Does
+
+Code for Connection is a communication platform for correctional facilities.
+It lets incarcerated people make phone calls, join video visits, and exchange
+text messages with their family members. Every interaction flows through
+facility staff, who can approve, monitor, and terminate communications as
+needed. The system serves four types of users across web browsers and
+facility-issued tablets.
+
+
+## Glossary
+
+These acronyms appear throughout the codebase and this document:
+
+| Term    | What It Means |
+|---------|---------------|
+| API     | Application Programming Interface: a set of rules that lets one program talk to another over a network |
+| JWT     | JSON Web Token: a small, signed piece of data that proves who a user is (like a digital ID badge) |
+| ORM     | Object-Relational Mapping: a tool that lets code talk to a database using regular programming objects instead of raw database queries |
+| PSTN    | Public Switched Telephone Network: the regular phone system (landlines and cell phones) |
+| SQL     | Structured Query Language: the standard language for reading and writing data in a database |
+| WebRTC  | Web Real-Time Communication: a browser technology that lets two people send audio and video directly to each other |
+| Socket  | A persistent two-way connection between a browser and a server, used for real-time updates |
+| Redis   | An in-memory data store used here to coordinate real-time events across server instances |
+| Prisma  | The specific ORM this project uses to talk to the PostgreSQL database |
+
+
+## User Roles
+
+The system has four roles. Each role sees a different interface.
+
+| Role             | Who They Are                              | How They Access the System      |
+|------------------|-------------------------------------------|---------------------------------|
+| incarcerated     | Person in a correctional facility         | Facility-issued tablet          |
+| family           | Family member or attorney outside         | Web browser on personal device  |
+| facility_admin   | Staff member at one specific facility     | Web dashboard                   |
+| agency_admin     | Staff overseeing all facilities in a state| Web dashboard                   |
+
+Agency admins can see and manage everything across all facilities.
+Facility admins can only see data for their assigned facility.
+
+
+## Services Overview
+
+The system runs three services, plus two data stores. Here is how they
+connect:
+
+```
++-------------------+         +-------------------+
+|                   |         |                   |
+|   Web App         |  HTTP   |   API Gateway     |
+|   (Vite/React)    +-------->|   (Express)       |
+|                   |         |                   |
+|   Port 5173       |         |   Port 3000       |
+|   Browser UI      |         |   All business    |
+|                   |         |   logic and        |
++--------+----------+         |   database calls  |
+         |                    |                   |
+         |                    +--------+----------+
+         |                             |
+         |  WebSocket                  | SQL queries
+         |  (real-time)                | via Prisma ORM
+         v                             v
++-------------------+         +-------------------+
+|                   |         |                   |
+|  Signaling Server |         |   PostgreSQL      |
+|  (Socket.IO)      |         |   Database        |
+|                   |         |                   |
+|  Port 3001        |         |   Port 5432       |
+|  Call setup and   |         |   All persistent  |
+|  real-time events |         |   data            |
+|                   |         |                   |
++--------+----------+         +-------------------+
+         |
+         | Pub/Sub
+         v
++-------------------+
+|                   |
+|   Redis           |
+|                   |
+|   Port 6379       |
+|   Coordinates     |
+|   events across   |
+|   server instances|
+|                   |
++-------------------+
+```
+
+**Web App** (port 5173): The browser application that all users interact
+with. Built with React (a user interface library) and served by Vite (a
+development server). Contains separate page layouts for each user role.
+
+**API Gateway** (port 3000): The backend server that handles all data
+operations. When a user takes an action (send a message, start a call), the
+web app sends an HTTP request here. The gateway checks the user's JWT token,
+verifies their role, then reads from or writes to the database. Built with
+Express (a web server framework for Node.js).
+
+**Signaling Server** (port 3001): Handles real-time communication during
+calls. When two people join a video or voice call, this server helps their
+browsers find each other and establish a direct WebRTC connection. Uses
+Socket.IO (a library for persistent two-way connections) and Redis to
+coordinate events.
+
+**PostgreSQL** (port 5432): The relational database that stores all
+persistent data: user accounts, call records, messages, facility
+configuration, contact lists, and blocked numbers. The codebase talks to it
+through Prisma, an ORM that translates code into SQL queries.
+
+**Redis** (port 6379): An in-memory data store that the signaling server
+uses to coordinate real-time events. If you run multiple copies of the
+signaling server (for reliability), Redis makes sure a message sent to one
+copy reaches users connected to a different copy.
+
+
+## Voice Call Flow
+
+Voice calls are phone calls. The incarcerated person initiates from a
+tablet, and the call is bridged to the family member's regular phone via
+Twilio (a third-party phone service) and the PSTN.
+
+```
+  Tablet                API Gateway           Twilio/PSTN        Family Phone
+    |                       |                     |                    |
+    | 1. POST /initiate-call|                     |                    |
+    |---------------------->|                     |                    |
+    |                       | 2. Check: contact   |                    |
+    |                       |    approved? Number  |                    |
+    |                       |    not blocked?      |                    |
+    |                       |    Within calling    |                    |
+    |                       |    hours?            |                    |
+    |                       |                     |                    |
+    |                       | 3. Create call       |                    |
+    |                       |    record (ringing)  |                    |
+    |                       |                     |                    |
+    |                       | 4. Bridge call ----->| 5. Ring phone ---->|
+    |                       |                     |                    |
+    |                       |                     |    6. Answer        |
+    |                       |<----- connected ----|<-------------------|
+    |                       |                     |                    |
+    | 7. Call in progress   |                     |                    |
+    |<=====================>|<===================>|<==================>|
+    |                       |                     |                    |
+    | 8. Time limit OR      |                     |                    |
+    |    admin terminates   |                     |                    |
+    |    OR either party    |                     |                    |
+    |    hangs up           |                     |                    |
+    |                       |                     |                    |
+    |                       | 9. Update record    |                    |
+    |                       |    (completed or    |                    |
+    |                       |     terminated)     |                    |
+```
+
+**Step by step:**
+
+1. The incarcerated person picks a contact on their tablet and taps "Call."
+2. The API Gateway checks that the contact is approved, the phone number is
+   not on any blocked list, and the current time is within the housing
+   unit's allowed calling hours.
+3. A new voice call record is created in the database with status "ringing."
+4. Twilio places an outbound call to the family member's phone number.
+5. The family member's phone rings.
+6. The family member answers.
+7. Audio flows between the tablet and the phone.
+8. The call ends when: the time limit is reached, an admin clicks
+   "Terminate" on their dashboard, or either party hangs up.
+9. The call record is updated with the end time, duration, and who ended it.
+
+**Admin capabilities during voice calls:**
+- View all active calls in their facility in real time
+- Terminate any active call immediately
+- Review call logs with date and participant filters
+
+
+## Video Call Flow
+
+Video calls use WebRTC, which means audio and video travel directly between
+the two browsers (not through our servers). The signaling server only helps
+set up the connection.
+
+```
+  Family           API Gateway        Admin           Signaling        Tablet
+    |                  |                |                 |               |
+    | 1. POST          |                |                 |               |
+    |  /request-visit  |                |                 |               |
+    |----------------->|                |                 |               |
+    |                  | 2. Create call |                 |               |
+    |                  |   (requested)  |                 |               |
+    |                  |                |                 |               |
+    |                  | 3. Appears in  |                 |               |
+    |                  |    pending --->|                 |               |
+    |                  |    requests    |                 |               |
+    |                  |                |                 |               |
+    |                  |  4. Approve    |                 |               |
+    |                  |<---------------|                 |               |
+    |                  |                |                 |               |
+    |                  | 5. Status ->   |                 |               |
+    |                  |    "scheduled" |                 |               |
+    |                  |                |                 |               |
+    |        ... time passes until scheduled start ...                   |
+    |                  |                |                 |               |
+    | 6. POST          |                |                 |               |
+    |  /join-call      |                |                 |               |
+    |----------------->|                |                 |               |
+    |                  |                |                 |               |
+    | 7. join-room ----|----------------|---------------->|               |
+    |                  |                |                 |<-- join-room -|
+    |                  |                |                 |    8.         |
+    |                  |                |                 |               |
+    | 9. WebRTC offer/answer exchange via signaling       |               |
+    |<--------------------------------------------------->|               |
+    |                  |                |                 |               |
+    | 10. Direct video/audio between browsers             |               |
+    |<====================================================>|              |
+    |                  |                |                 |               |
+    |  11. Call ends (time limit, admin, or either party) |               |
+```
+
+**Step by step:**
+
+1. The family member logs in to the web app and requests a video visit,
+   picking a time slot.
+2. A video call record is created in the database with status "requested."
+3. The request appears on the facility admin's dashboard under "Pending
+   Requests."
+4. The admin reviews and approves (or denies) the request.
+5. If approved, the status changes to "scheduled."
+6. At the scheduled time, both parties click "Join" in the web app.
+7. The family member's browser connects to the signaling server and joins a
+   room.
+8. The incarcerated person's tablet does the same.
+9. The signaling server relays WebRTC "offer" and "answer" messages so the
+   two browsers can find each other.
+10. Once connected, video and audio flow directly between the two browsers.
+11. The call ends when the time limit is reached, an admin terminates it, or
+    either party leaves.
+
+**Admin capabilities during video calls:**
+- View all active video calls
+- Approve or deny visit requests
+- Terminate any active call
+- Review call history and statistics
+
+
+## Message Lifecycle
+
+All text messages pass through an admin review step before delivery. This is
+a core compliance requirement.
+
+```
++----------+     +--------------+     +--------------+     +----------+
+|          |     |              |     |              |     |          |
+|  Sender  |---->| pending_review|--->|   approved   |---->| delivered|
+|  writes  |     |              |     |   (admin)    |     |          |
+|  message |     |  Waiting for |     |              |     +----+-----+
+|          |     |  admin       |     +--------------+          |
++----------+     |  review      |            |                  v
+                 |              |            |            +----------+
+                 +--------------+            |            |          |
+                        |                    v            |   read   |
+                        |             +--------------+    |          |
+                        +------------>|   blocked    |    +----------+
+                          (admin      |   (rejected) |
+                           rejects)   +--------------+
+```
+
+**Step by step:**
+
+1. Either the incarcerated person or the family member writes a message.
+2. The message is saved to the database with status "pending_review."
+3. The message appears in the admin's review queue.
+4. The admin reads the message and either approves or blocks it.
+5. If approved, the message becomes visible to the recipient.
+6. When the recipient opens the conversation, the status updates to "read."
+
+Messages can include image attachments. Attachments go through their own
+review process (pending_review, approved, or rejected).
+
+Admins can also block an entire conversation, which prevents any further
+messages between those two people.
+
+
+## Directory Map
+
+The codebase is organized as a monorepo (one repository containing multiple
+projects that share code). Here is what each top-level directory contains:
+
+```
+code-for-connection/
+|
+|-- guilds/                  Feature modules (the main application code)
+|   |-- admin/               Dashboard features: user management, contacts,
+|   |   |-- api/routes.ts      blocked numbers, facility configuration
+|   |   |-- ui/index.tsx
+|   |
+|   |-- voice/               Phone call features
+|   |   |-- api/routes.ts    Backend: initiate calls, active call list,
+|   |   |-- ui/                terminate, call logs, stats
+|   |   |   |-- admin/       Admin sees active calls and logs
+|   |   |   |-- family/      Family sees call history
+|   |   |   |-- incarcerated/ Incarcerated person sees contacts and dialer
+|   |
+|   |-- video/               Video visit features
+|   |   |-- api/routes.ts    Backend: request visits, approve/deny,
+|   |   |-- ui/                join calls, terminate, stats
+|   |   |   |-- admin/       Admin sees requests and active calls
+|   |   |   |-- family/      Family requests visits and joins calls
+|   |   |   |-- incarcerated/ Incarcerated person sees schedule and joins
+|   |
+|   |-- messaging/           Text messaging features
+|   |   |-- api/routes.ts    Backend: send messages, review queue,
+|   |   |-- ui/                approve/block, conversation list
+|   |   |   |-- admin/       Admin sees review queue
+|   |   |   |-- family/      Family sees conversations
+|   |   |   |-- incarcerated/ Incarcerated person sees conversations
+|   |
+|   |-- shared/hooks/        Shared frontend utilities
+|       |-- useGuildApi.ts   Makes HTTP requests to the API Gateway
+|       |-- useSocket.ts     Manages signaling server connections
+|       |-- useCallTimer.ts  Tracks call duration and time limits
+|
+|-- packages/
+|   |-- shared/              Code shared across all services
+|   |   |-- src/auth/        JWT token creation, verification, and
+|   |   |                      role-checking middleware
+|   |   |-- src/db/          Database client (Prisma) setup
+|   |   |-- src/types/       Data type definitions
+|   |   |-- src/utils/       Error handling, pagination, date helpers
+|   |
+|   |-- ui/                  Shared visual components (buttons, cards,
+|                              modals, form inputs, etc.)
+|
+|-- apps/
+|   |-- web/                 The browser application: URL routing,
+|                              page layouts, role-based navigation
+|
+|-- services/
+|   |-- api-gateway/         Express server (port 3000) that mounts
+|   |   |-- src/               all guild routers under /api/*
+|   |   |   |-- routes/auth  Login and token endpoints
+|   |
+|   |-- signaling/           Socket.IO server (port 3001) for
+|                              real-time call events and WebRTC setup
+|
+|-- prisma/
+|   |-- schema.prisma        Database table definitions (the source
+|                              of truth for all data structures)
+|
+|-- deploy/                  Docker, Terraform, and deployment scripts
+|-- docker-compose.yml       Runs PostgreSQL, Redis, and the signaling
+                               server in containers for local development
+```
+
+
+## How the Pieces Connect
+
+Each guild follows the same pattern:
+
+- **Backend** (`guilds/{name}/api/routes.ts`): Defines the HTTP endpoints
+  (URLs) that the API Gateway serves. Every route checks authentication
+  (is this a valid user?) and authorization (does this user's role allow
+  this action?) using middleware from `packages/shared`.
+
+- **Frontend** (`guilds/{name}/ui/{role}/index.tsx`): Defines what each
+  user role sees for that feature. The admin view for voice calls shows
+  active calls and logs. The incarcerated view shows a contact list and
+  dial button.
+
+The API Gateway (`services/api-gateway`) imports all guild routers and
+mounts them:
+- `/api/auth` for login and token management
+- `/api/admin` for the admin guild
+- `/api/voice` for the voice guild
+- `/api/video` for the video guild
+- `/api/messaging` for the messaging guild
+
+
+## Authentication Flow
+
+1. A user logs in by sending their credentials to `/api/auth`.
+2. The server verifies the credentials and returns a JWT (JSON Web Token).
+3. The browser stores this token and includes it in every subsequent request
+   as an `Authorization` header.
+4. On each request, the `requireAuth` middleware extracts the token, verifies
+   it, and attaches the user's identity (id, role, facility) to the request.
+5. The `requireRole` middleware then checks whether the user's role is
+   allowed for that specific endpoint.
+
+Agency admins can access data across all facilities. Facility admins are
+restricted to their assigned facility. Incarcerated users and family members
+can only access their own data.
+
+
+## Data Model (Key Tables)
+
+The database schema lives in `prisma/schema.prisma`. Here are the most
+important tables and how they relate:
+
+```
+Agency (e.g., "State DOC")
+  |
+  +-- Facility (e.g., "North Regional")
+  |     |
+  |     +-- HousingUnit (e.g., "Block A")
+  |     |     |
+  |     |     +-- IncarceratedPerson
+  |     |
+  |     +-- AdminUser (facility_admin)
+  |     +-- VoiceCall
+  |     +-- VideoCall
+  |     +-- VideoCallTimeSlot
+  |     +-- BlockedNumber
+  |
+  +-- AdminUser (agency_admin)
+  +-- HousingUnitType (calling rules: hours, duration limits, max contacts)
+
+FamilyMember (independent of facility)
+  |
+  +-- ApprovedContact (links a family member to an incarcerated person)
+  +-- Conversation
+        |
+        +-- Message
+              |
+              +-- MessageAttachment
+```
+
+**HousingUnitType** defines the rules for a class of housing units: how long
+calls can last, what hours calling is allowed, how many contacts a person
+can have, and how many concurrent video calls are permitted.
+
+**ApprovedContact** is the link between an incarcerated person and a family
+member. Contacts must be approved by an admin before any communication can
+happen. Contacts can also be marked as attorney relationships (which may
+have different monitoring rules).
+
+**BlockedNumber** can be scoped to a single facility or to an entire agency.

--- a/doc/GLOSSARY.md
+++ b/doc/GLOSSARY.md
@@ -1,0 +1,86 @@
+# Glossary
+
+This glossary defines terms you will encounter in the Code for Connection codebase and in conversations about correctional facility communication systems. It is written for someone new to both the domain and the technology.
+
+---
+
+## Domain Terms
+
+**Agency**
+A state department (for example, NY DOCCS) that oversees multiple correctional facilities.
+
+**Approved contact**
+A family member or other person who has been verified and authorized to communicate with a specific incarcerated person.
+
+**Facility**
+A single correctional institution (for example, Sing Sing).
+
+**Guild**
+A self-contained feature module in the codebase. Each guild (voice, video, messaging, admin) has its own API routes and UI components.
+
+**Housing unit**
+A section within a facility. Different unit types may have different communication rules, such as call duration limits or permitted hours.
+
+**Incarcerated person / Resident**
+Someone currently held in a correctional facility who uses the tablet interface to communicate with approved contacts.
+
+**Pending review**
+A message state where content is waiting for an administrator to approve it before it is delivered to the recipient.
+
+**PSTN (Public Switched Telephone Network)**
+The regular phone system that most people use at home. Twilio bridges internet-based calls to the PSTN so that approved contacts can receive calls on ordinary phone numbers.
+
+**Signaling**
+The process of coordinating call setup (who is calling whom, when to connect) before actual audio or video begins flowing.
+
+---
+
+## Technical Terms
+
+**API (Application Programming Interface)**
+A set of URLs that the frontend calls to retrieve data or trigger actions on the server.
+
+**API Gateway**
+The Express server that receives incoming HTTP requests and routes them to the correct guild backend.
+
+**Docker**
+A tool that packages an application and all of its dependencies into a container, so it runs the same way on any machine.
+
+**ECS (Elastic Container Service)**
+An AWS service that runs Docker containers without requiring you to manage the underlying servers.
+
+**Express**
+The Node.js web framework used for the API server in this project.
+
+**JWT (JSON Web Token)**
+An encoded token sent with each request to prove the user's identity. The server checks this token to decide whether the request is allowed.
+
+**ORM (Object-Relational Mapping)**
+A layer that lets you write database queries in TypeScript instead of raw SQL.
+
+**Prisma**
+The specific ORM used in this project. Its schema is defined in `prisma/schema.prisma`.
+
+**RDS (Relational Database Service)**
+An AWS managed PostgreSQL database. It handles backups, patching, and scaling so you do not have to run a database server yourself.
+
+**React**
+The JavaScript library used to build the user interface in this project.
+
+**Redis**
+An in-memory data store used here for real-time signaling pub/sub (publishing and subscribing to messages between services).
+
+**Socket.IO**
+A library for real-time, two-way communication between the browser and the server. It is used for call signaling in this project.
+
+**Terraform**
+An infrastructure-as-code tool that creates and manages cloud resources from configuration files, so infrastructure changes are reviewable and repeatable.
+
+**Twilio**
+A third-party service that connects internet-based calls to regular phone numbers on the PSTN.
+
+**Vite**
+The build tool that bundles the React frontend for both development and production.
+
+**WebRTC (Web Real-Time Communication)**
+A browser technology that enables peer-to-peer video and audio calls without requiring a plugin.

--- a/guilds/shared/hooks/useCallTimer.ts
+++ b/guilds/shared/hooks/useCallTimer.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+export function useCallTimer(durationSeconds: number, warningThresholdSeconds = 60) {
+  const [timeRemaining, setTimeRemaining] = useState(durationSeconds);
+  const [running, setRunning] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!running) return;
+
+    intervalRef.current = setInterval(() => {
+      setTimeRemaining((prev) => {
+        if (prev <= 1) {
+          clearInterval(intervalRef.current!);
+          setRunning(false);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [running]);
+
+  const start = useCallback(() => setRunning(true), []);
+  const stop = useCallback(() => setRunning(false), []);
+  const reset = useCallback(() => {
+    setRunning(false);
+    setTimeRemaining(durationSeconds);
+  }, [durationSeconds]);
+
+  const minutes = Math.floor(timeRemaining / 60);
+  const seconds = timeRemaining % 60;
+  const formattedTime = `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+
+  return {
+    timeRemaining,
+    isWarning: timeRemaining <= warningThresholdSeconds && timeRemaining > 0,
+    isExpired: timeRemaining <= 0,
+    formattedTime,
+    start,
+    stop,
+    reset,
+  };
+}

--- a/guilds/shared/hooks/useGuildApi.ts
+++ b/guilds/shared/hooks/useGuildApi.ts
@@ -1,0 +1,35 @@
+import { useCallback } from 'react';
+import { useAuth } from '../../../apps/web/src/context/AuthContext';
+
+export function useGuildApi(basePath: string) {
+  const { token } = useAuth();
+
+  const request = useCallback(
+    async (method: string, path: string, body?: unknown) => {
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+      };
+      if (body !== undefined) {
+        headers['Content-Type'] = 'application/json';
+      }
+      const response = await fetch(`${basePath}${path}`, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error?.message || `Request failed: ${response.status}`);
+      }
+      return data;
+    },
+    [token, basePath]
+  );
+
+  const get = useCallback((path: string) => request('GET', path), [request]);
+  const post = useCallback((path: string, body?: unknown) => request('POST', path, body), [request]);
+  const patch = useCallback((path: string, body: unknown) => request('PATCH', path, body), [request]);
+  const del = useCallback((path: string) => request('DELETE', path), [request]);
+
+  return { get, post, patch, del };
+}

--- a/guilds/shared/hooks/useSocket.ts
+++ b/guilds/shared/hooks/useSocket.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { io, Socket } from 'socket.io-client';
+
+const SIGNALING_URL = import.meta.env.VITE_SIGNALING_URL || 'http://localhost:3001';
+
+export function useSocket() {
+  const socketRef = useRef<Socket | null>(null);
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    const socket = io(SIGNALING_URL, { transports: ['websocket'] });
+    socketRef.current = socket;
+
+    socket.on('connect', () => setConnected(true));
+    socket.on('disconnect', () => setConnected(false));
+
+    return () => {
+      socket.disconnect();
+      socketRef.current = null;
+    };
+  }, []);
+
+  const emit = useCallback((event: string, data?: unknown) => {
+    socketRef.current?.emit(event, data);
+  }, []);
+
+  const on = useCallback((event: string, handler: (...args: unknown[]) => void) => {
+    socketRef.current?.on(event, handler);
+  }, []);
+
+  const off = useCallback((event: string, handler?: (...args: unknown[]) => void) => {
+    socketRef.current?.off(event, handler);
+  }, []);
+
+  return { socket: socketRef.current, connected, emit, on, off };
+}


### PR DESCRIPTION
## Summary

From the admin guild team. Three shared React hooks and two documentation files, offered as optional utilities for the video guild.

**Shared hooks** (`guilds/shared/hooks/`):
- `useGuildApi(basePath)`: Authenticated fetch wrapper (generalization of the admin guild's useAdminApi)
- `useSocket()`: Socket.IO connection to the signaling server
- `useCallTimer(seconds)`: Countdown timer with warning threshold

**Documentation** (`doc/`):
- `ARCHITECTURE.md`: Plain-language system overview for future maintainers
- `GLOSSARY.md`: Domain and technical terms

These are additive (no changes to existing files). Use them if helpful, close this PR if not.

Note: we've updated our own branch to use "video calls" rather than "video visits" per the terminology guidance in GUILD_VIDEO_SPEC.md.

Generated with [Claude Code](https://claude.com/claude-code)